### PR TITLE
fix: use ga tracking id as public env var

### DIFF
--- a/src/ga.js
+++ b/src/ga.js
@@ -1,6 +1,6 @@
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url) => {
-  window.gtag("config", GA_TRACKING_ID, {
+  window.gtag("config", process.env.NEXT_PUBLIC_GA_TRACKING_ID, {
     page_path: url
   });
 };

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,7 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
 
-const GA_TRACKING_ID = "UA-84677777-1";
+const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {


### PR DESCRIPTION
Fix GA tracking ID, which was missing when tracking page view
